### PR TITLE
UHF-X post install

### DIFF
--- a/tools/make/project/install.mk
+++ b/tools/make/project/install.mk
@@ -4,7 +4,7 @@ ifeq ($(DRUPAL_VERSION),8)
 	else
 	    DRUPAL_NEW_TARGETS := up build drush-si drush-enable-modules drush-locale-update drush-uli
 	endif
-    DRUPAL_POST_INSTALL_TARGETS := drush-updb drush-locale-update drush-cim drush-uli
+    DRUPAL_POST_INSTALL_TARGETS := drush-cim drush-updb drush-locale-update drush-uli
 endif
 
 PHONY += drush-enable-modules

--- a/tools/make/project/install.mk
+++ b/tools/make/project/install.mk
@@ -4,7 +4,7 @@ ifeq ($(DRUPAL_VERSION),8)
 	else
 	    DRUPAL_NEW_TARGETS := up build drush-si drush-enable-modules drush-locale-update drush-uli
 	endif
-    DRUPAL_POST_INSTALL_TARGETS := drush-cim drush-updb drush-locale-update drush-uli
+    DRUPAL_POST_INSTALL_TARGETS := drush-deploy drush-locale-update drush-uli
 endif
 
 PHONY += drush-enable-modules


### PR DESCRIPTION
Switched to `drush-deploy`. With this command on every drupal instance we can at least try to update configurations with hook_deploy_NAME.