### PR TITLE
UHF-X Composer v2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
             "make cast-spell",
             "@copy-commit-message-script"
         ],
-        "post-update-cmd": [
+        "post-install-cmd": [
             "@copy-commit-message-script"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -95,9 +95,6 @@
             "make cast-spell",
             "@copy-commit-message-script"
         ],
-        "post-install-cmd": [
-            "@copy-commit-message-script"
-        ],
         "post-update-cmd": [
             "@copy-commit-message-script"
         ]


### PR DESCRIPTION
Running `composer create-project ...` on composer 2.1 produces
![image](https://user-images.githubusercontent.com/1712902/121895751-3fa40880-cd29-11eb-9421-937c36f672fa.png)


Temporarily removed the "git commit hook file" copy procedure from post update cmd.