### PR TITLE
UHF-5426 Email update

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -9,6 +9,8 @@ command:
       options:
         # Set a predetermined username and password when using site-install.
         account-name: 'helfi-admin'
+        account-mail: 'drupal@hel.fi'
+        site-mail: 'drupal@hel.fi'
 
 sql:
   # List of tables whose *data* is skipped by the 'sql-dump' and 'sql-sync'


### PR DESCRIPTION
# [UHF-5426](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5426)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Set default site-mail and account-mail to drupal@hel.fi

## How to install

* ```composer create-project City-of-Helsinki/drupal-helfi-platform:dev-UHF-5426_email_update hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/```
* Run `make new`
* Log in and go to https://hel-platform.docker.so/fi/user/1/edit and https://hel-platform.docker.so/fi/admin/config/system/site-information
   * Check that the email is `drupal@hel.fi`

## Check also
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/338