### PR TITLE
UHF-7959: Allow guzzle 7 to be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ PHP 8.1 is now the default PHP version.
 2. Verify and test changes locally
 3. Update `DRUPAL_DOCKER_TAG` value to `8.1` or `8.1-dev` on Azure DevOps (if set).
 
+### Optional actions
+
+Update guzzle to newer version to fix deprecation warnings:
+
+1. Remove `drupal/core-recommended` package from your `composer.json`
+2. Check if you have `weitzman/drupal-test-traits` package installed: `composer show weitzman/drupal-test-traits`. If it's installed you have to update it to version 2.0: `composer require --dev weitzman/drupal-test-traits:^2.0`.
+3. Run `composer update`
+
 ## 2022-05-31.1
 
 Added documentation of how to sync databases between OpenShift environments: [documentation/openshift-db-sync.md](/documentation/openshift-db-sync.md).

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     "require": {
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.6.7",
-        "drupal/core-composer-scaffold": "^9.3",
-        "drupal/core-recommended": "^9.3",
+        "drupal/core-composer-scaffold": "^9.5",
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_azure_fs": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "weitzman/drupal-test-traits": "^1.5"
+        "weitzman/drupal-test-traits": "^2.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
To test this:

- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-UHF-7959 drupal --no-interaction --repository https://repository.drupal.hel.ninja`
- `cd drupal`
- Make sure guzzle version 7+ is installed: `composer show "guzzlehttp/*"`