### PR TITLE
PLAENH-607 - prevent cron running during deployment

### DIFF
--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+# Checking if a new deployment is in progress, as we should not run cron while deploying.
+if [ ! -n "$OPENSHIFT_BUILD_NAME" ]; then
+  echo "OPENSHIFT_BUILD_NAME is not defined. Exiting early."
+  exit 1
+fi
+
+while [ "$(drush state:get deploy_id)" != "$OPENSHIFT_BUILD_NAME" ]
+do
+  echo "Current deploy_id $OPENSHIFT_BUILD_NAME not found in state. Probably a deployment is in progress - waiting for completion..."
+  sleep 60
+done
+
+while [ "$(drush state:get system.maintenance_mode)" = "1" ]
+do
+  echo "Maintenance mode on. Probably a deployment is in progress - waiting for completion..."
+  sleep 60
+done
+
 echo "Starting cron: $(date)"
 
 # You can add any additional cron "daemons" here:


### PR DESCRIPTION
# [PLAENH-607](https://helsinkisolutionoffice.atlassian.net/browse/PLAENH-607)
To prevent cron running when a deployment is in progress.
The assumption is that the new cron container may be up before the deploy of app container finishes, so initialising the cron job loops and sh should wait till proper states are found - deploy_id and system.maintenance_mode


## How to install
This can be tested in openshift

## How to test
After deploying the new version, we should find in cron container logs "Current deploy_id ... not found in state. Probably a deployment is in progress - waiting for completion"
And after 1 or more minutes we should see "Starting cron:...."



[PLAENH-607]: https://helsinkisolutionoffice.atlassian.net/browse/PLAENH-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ