### PR TITLE
PLATTA-4794 - disable garbage collector for non cli requests

### DIFF
--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -5,6 +5,12 @@ use Symfony\Component\HttpFoundation\Request;
 if (PHP_SAPI === 'cli') {
   ini_set('memory_limit', '512M');
 }
+else {
+  // New relic triggers garbage collector which adds extra time on the request.
+  // The gc enabled is useful for migration drush commands and probably others.
+  // For non cli requests, there should not be a case where gc is called / needed.
+  ini_set('zend.enable_gc', 'Off');
+}
 
 if ($simpletest_db = getenv('SIMPLETEST_DB')) {
   $parts = parse_url($simpletest_db);


### PR DESCRIPTION
# [PLATTA-4794](https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4794)
For projects using newrelic, garbage collector is called by newrelic extension which adds extra time.
The usual recommendation is to not have garbage collector called during a request, as it adds lot of time to the request, but for migration drush commands for example, garbage collector is needed.
Initially we've got gc disabled trough the base image, now switching to this approach

## What was done
For non cli requests, do  ini_set('zend.enable_gc', 'Off');

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout PLATTA-4794`
  * `make fresh`
* Run `make drush-cr`

## How to test
- php --info | grep enable_gc  - should be On
- going to  /admin/reports/status/php should say zend.enable_gc=Off



[PLATTA-4794]: https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ