### PR TITLE
PLATTA-4943: Added test for checking if a module exists

### DIFF
--- a/tests/dtt/src/ExistingSite/ModuleEnabledTest.php
+++ b/tests/dtt/src/ExistingSite/ModuleEnabledTest.php
@@ -16,7 +16,7 @@ class ModuleEnabledTest extends ExistingSiteBase {
   /**
    * Check if dblog is enabled.
    */
-  public function testDbLogEnabled() {
+  public function testDbLogEnabled(): void {
     // Assert that the dblog module is not enabled.
     $this->assertFalse(\Drupal::moduleHandler()->moduleExists('dblog'));
   }

--- a/tests/dtt/src/ExistingSite/ModuleEnabledTest.php
+++ b/tests/dtt/src/ExistingSite/ModuleEnabledTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\dtt\ExistingSite;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests if a specific module is enabled.
+ *
+ * @group dtt
+ */
+class ModuleEnabledTest extends ExistingSiteBase {
+
+  /**
+   * Check if dblog is enabled.
+   */
+  public function testDbLogEnabled() {
+    // Assert that the dblog module is not enabled.
+    $this->assertFalse(\Drupal::moduleHandler()->moduleExists('dblog'));
+  }
+
+}


### PR DESCRIPTION
Issue: https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4943

Added dtt test to check if a module is enabled. At this point only dblog, if it is enabled the test will fail.