### PR TITLE
UHF-8510: Document commands for building assets in containers

### DIFF
--- a/public/themes/custom/hdbt_subtheme/README.md
+++ b/public/themes/custom/hdbt_subtheme/README.md
@@ -25,15 +25,20 @@ Requirements for developing:
 
 ## Commands
 
-| Command       | Description                                                                       |
-| ------------- | --------------------------------------------------------------------------------- |
-| nvm use       | Uses correct Node version chosen for the subtheme compiler                        |
-| npm i         | Install dependencies and link local packages.                                     |
-| npm ci        | Install a project with a clean slate. Use especially in travis like environments. |
-| npm run dev   | Compile styles for development environment and watch file changes.                |
-| npm run build | Build packages for production. Minify CSS/JS. Create icon sprite.                 |
+| Command       | Make command               | Description                                                                       |
+|---------------|----------------------------|-----------------------------------------------------------------------------------|
+| nvm use       | N/A                        | Uses correct Node version chosen for the subtheme compiler                        |
+| npm i         | make install-hdbt-subtheme | Install dependencies and link local packages.                                     |
+| npm ci        | N/A                        | Install a project with a clean slate. Use especially in travis like environments. |
+| npm run dev   | make watch-hdbt-subtheme   | Compile styles for development environment and watch file changes.                |
+| npm run build | make watch-hdbt-subtheme   | Build packages for production. Minify CSS/JS. Create icon sprite.                 |
 
-Setup the developing environment by running
+Consistent Node version defined in `.nvmrc` should be used. For development, use either `nvm` to select the correct
+version or `make` commands that select the version automatically. Run `make` the commands from the table above in the
+project directory of your instance. For more information, see
+[build-assets.md](https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/documentation/build-assets.md).
+
+Set up the developing environment with `nvm` by running
 
     nvm use
     npm i


### PR DESCRIPTION
# [UHF-8510](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8510)
<!-- What problem does this solve? -->

## What was done
Make commands for compiling the theme were already documented in [City-of-Helsinki/drupal-helfi-platform](https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/documentation/build-assets.md) repository. This PR adds description of the commands to this repository so they are easier to find.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8510-document-theme-build-commands`

## How to test

* [ ] Follow README.md instructions.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* City-of-Helsinki/drupal-helfi-platform#131
