### PR TITLE
UHF-8255 Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,3 @@ You can run `make help` to list all available commands for you.
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.