### PR TITLE
UHF-X: allow fixup commits

### DIFF
--- a/tools/commit-msg
+++ b/tools/commit-msg
@@ -4,12 +4,13 @@
 # feature/PROJECT-1234-test-test
 # PROJECT-1234-test-test
 # PROJECT-1234_test_test
+# fixup! (for git rebase --autosquash)
 id=$(echo `git rev-parse --abbrev-ref HEAD` | sed -nE 's|([a-z]+/)?([A-Z]+-[0-9]+)(-.+)?(_.+)?|\2|p')
 COMMIT_MESSAGE=$(cat $1)
 
 # Only prepare commit message if pattern matched and Jira ID was found and
 # message doesn't contain Jira ID already.
-if [[ ! -z $id ]] && [[ $COMMIT_MESSAGE != $id* ]]; then
+if [[ ! -z $id ]] && [[ $COMMIT_MESSAGE != $id* ]] && [[ $COMMIT_MESSAGE != "fixup!"* ]]; then
   # $1 is the name of the file containing the commit message
   # Prepend "ABCD-123: "
   sed -i.bak -E "1s/^/${id}: /" $1


### PR DESCRIPTION
This fixes a minor annoyance in my workflow. The current git hook messes up fixup commits, so `git rebase --autosquash` does not work.

See: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash