### PR TITLE
Conflict on D10.2 for now.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "weitzman/drupal-test-traits": "^2.0"
     },
     "conflict": {
-        "drupal/drupal": "*"
+        "drupal/drupal": "*",
+        "drupal/core": "<10.1 || >=10.2"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
     },
     "conflict": {
         "drupal/drupal": "*",
-        "drupal/core": "<10.1 || >=10.2"
+        "drupal/core": ">=10.2",
+        "drupal/core-composer-scaffold": ">=10.2",
+        "drupal/core-dev": ">=10.2"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Do not use Drupal 10.2 until [the issues with it](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9488) have been fixed.
