### PR TITLE
UHF-9488 Drupal 10.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,7 @@
         "weitzman/drupal-test-traits": "^2.0"
     },
     "conflict": {
-        "drupal/drupal": "*",
-        "drupal/core": ">=10.2",
-        "drupal/core-composer-scaffold": ">=10.2",
-        "drupal/core-dev": ">=10.2"
+        "drupal/drupal": "*"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
# [UHF-9488](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9488)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed version constraints for Drupal 10.2.0


[UHF-9488]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ