### PR TITLE
UHF-9656: Use COMPOSE_PROJECT_NAME as hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3.7'
 
 services:
   app:
-    hostname: "${DRUPAL_HOSTNAME}"
     container_name: "${COMPOSE_PROJECT_NAME}-app"
     image: "${DRUPAL_IMAGE}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   app:
     container_name: "${COMPOSE_PROJECT_NAME}-app"
     image: "${DRUPAL_IMAGE}"
+    hostname: "${COMPOSE_PROJECT_NAME}"
     volumes:
       - .:/app:delegated
     depends_on:


### PR DESCRIPTION
Alpine or Docker (not sure which) seems to fallback all non-existent domains (like `app`, `elastic`) to `127.0.0.1` if hostname is set to `xxxx.docker.so`.

For example:
![image](https://github.com/City-of-Helsinki/drupal-helfi-platform/assets/771113/f3a82aa9-4de1-4a24-86dc-77140bdbfe1e)
