### PR TITLE
UHF-9576: Add cron job for linked events migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
             "phpstan/extension-installer": true
+        },
+        "audit": {
+            "abandoned": "report"
         }
     },
     "extra": {

--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -20,6 +20,8 @@ echo "Starting cron: $(date)"
 
 # Uncomment this to enable TPR migration cron
 #exec "/crons/migrate-tpr.sh" &
+# Uncomment this to enable linked events migrations cron
+#exec "/crons/linked-events.sh" &
 # Uncomment this to enable Varnish purge cron
 #exec "/crons/purge-queue.sh" &
 # Uncomment this to enable automatic translation updates.

--- a/docker/openshift/crons/linked-events.sh
+++ b/docker/openshift/crons/linked-events.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while true
+do
+  # Allow migrations to be run every 3 hours and reset stuck migrations every 12 hours.
+  drush migrate:import linked_events_keywords --interval 10800 --reset-threshold 43200 --no-progress
+
+  # Sleep for 12 hours
+  sleep 86400
+done


### PR DESCRIPTION
# [UHF-9576](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9576)
<!-- What problem does this solve? -->

## What was done

- Add `docker/openshift/crons/linked-events.sh`.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/710
* https://github.com/City-of-Helsinki/drupal-tools/pull/26

[UHF-9576]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ