### PR TITLE
Fix preflight script

### DIFF
--- a/docker/openshift/entrypoints/10-preflight.sh
+++ b/docker/openshift/entrypoints/10-preflight.sh
@@ -4,6 +4,8 @@ source /init.sh
 
 if [ -f "../docker/openshift/preflight/preflight.php" ]; then
   echo "Running preflight checks ..."
-  php ../docker/openshift/preflight/preflight.php
+  if ! php ../docker/openshift/preflight/preflight.php; then
+    exit 1
+  fi
 fi
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Preflight script does not check exit code correctly.

## How to install

* Switch to production image on your instance: https://github.com/City-of-Helsinki/drupal-docker-images/tree/main/openshift/drupal#testing-production-image-locally
* Add following changes to docker-compose.yml:
```diff
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,13 @@ services:
     image: "${DRUPAL_IMAGE}"
     hostname: "${COMPOSE_PROJECT_NAME}"
     volumes:
-      - .:/app:delegated
+      - .:/var/www/html:delegated
     depends_on:
       - db
     environment:
+      OPENSHIFT_BUILD_NAME: "123"
+      SENTRY_DSN: '123'
+      SENTRY_ENVIRONMENT: '123'
       STAGE_FILE_PROXY_ORIGIN: "${STAGE_FILE_PROXY_ORIGIN}"
       STAGE_FILE_PROXY_ORIGIN_DIR: "${STAGE_FILE_PROXY_ORIGIN_DIR}"
       APP_ENV: "${APP_ENV:-local}"
```
 * Run `make up shell` and
   * `cp /var/www/html/docker/openshift/entrypoints/10-preflight.sh /entrypoints/`
   * `cp /var/www/html/docker/openshift/init.sh /`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run `make stop && make up`. Docker container should not start.
* [ ] Verify container logs: Entrypoint executed preflight script and nothing after it.