### PR TITLE
UHF-10127: Cors headers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -105,6 +105,12 @@ services:
       - "traefik.http.services.nginx.loadbalancer.server.port=8080"
       - "traefik.http.routers.nginx.tls=true"
       - "traefik.docker.network=stonehenge-network"
+      - "traefik.http.middlewares.cors-header.headers.accesscontrolallowmethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors-header.headers.accesscontrolallowheaders=*"
+      - "traefik.http.middlewares.cors-header.headers.accesscontrolalloworiginlist=*"
+      - "traefik.http.middlewares.cors-header.headers.accesscontrolmaxage=100"
+      - "traefik.http.middlewares.cors-header.headers.addvaryheader=true"
+      - "traefik.http.routers.nginx.middlewares=cors-header"
     depends_on:
       - elastic
     profiles:


### PR DESCRIPTION
## How to install

- Copy compose.yaml to your project
- Run `make stop up`

## How to test
- Make sure `/fi/uutiset` endpoint does not complain about CORS headers