### PR TITLE
UHF-10102: Allow comma separated index names in proxy URLs

### DIFF
--- a/docker/elastic-proxy/elastic.conf
+++ b/docker/elastic-proxy/elastic.conf
@@ -8,7 +8,7 @@ server {
       return 200 '{"status":"success","result":"Proxy alive"}';
     }
 
-    location ~ ^/([a-z][a-z_-]*)/(_search|_msearch)$ {
+    location ~ ^/([a-z][a-z_,-]*)/(_search|_msearch)$ {
         limit_except GET POST {
            deny all;
         }


### PR DESCRIPTION
# [UHF-10102](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10102)

## What was done
Allows comma separated index names in elastic nginx proxy.

## How to test

* [ ] Testing instructions in separate PR: https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/889
* [ ] Check that the documentation changes make sense: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/8202256385/ElasticSearch+React+search+apps+and+Proxys
* [ ] Check that code follows our standards

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated

## Other PRs
* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/425
* Other related PRs listed in HDBT repo: https://github.com/City-of-Helsinki/drupal-hdbt/pull/1007 


[UHF-10102]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ