### PR TITLE
UHF-9493: Lock Drupal version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         "weitzman/drupal-test-traits": "^2.0"
     },
     "conflict": {
-        "drupal/drupal": "*"
+        "drupal/drupal": "*",
+        "drupal/core": ">=10.3",
+        "drupal/core-composer-scaffold": ">=10.3",
+        "drupal/core-dev": ">=10.3"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
# [UHF-9493](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9493)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Lock version until patches are fixed.


[UHF-9493]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ