### PR TITLE
Run drush-deploy before local-update

### DIFF
--- a/tools/make/project/install.mk
+++ b/tools/make/project/install.mk
@@ -3,7 +3,7 @@ ifeq ($(DRUPAL_CONF_EXISTS),yes)
 else
 	DRUPAL_NEW_TARGETS := up build drush-si drush-helfi-enable-modules drush-locale-update drush-helfi-locale-import drush-unblock drush-uli
 endif
-DRUPAL_POST_INSTALL_TARGETS := drush-locale-update drush-deploy drush-helfi-locale-import drush-unblock
+DRUPAL_POST_INSTALL_TARGETS := drush-deploy drush-locale-update drush-helfi-locale-import drush-unblock
 
 OC_LOGIN_TOKEN ?= $(shell bash -c 'read -s -p "You must obtain an API token by visiting https://oauth-openshift.apps.arodevtest.hel.fi/oauth/token/request (Token):" token; echo $$token')
 


### PR DESCRIPTION
If drush update commands are needed with drush locale update command, make fresh command fails.

# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

Make fresh fails if update hooks are needed in locale update. Also there's no reason to first update translations and after run other commands.

## What was done
<!-- Describe what was done -->

* Drush deploy is run first.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout run-drush-deploy-1st`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See that drush deploy is run before other commands and the process works as intended.
* [ ] Check that code follows our standards
