### PR TITLE
Autoload Drush\\Style

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,12 @@
             "Drupal\\Tests\\dtt\\": "tests/dtt/src"
         }
     },
+    "autoload": {
+        "psr-4": {
+            "Drush\\Style\\": "vendor/drush/drush/src-symfony-compatibility/v6/Style",
+            "Drush\\Symfony\\": "vendor/drush/drush/src-symfony-compatibility/v6/Symfony"
+        }
+    },
     "repositories": [
         {
             "type": "composer",


### PR DESCRIPTION
# [UHF-10844](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10844)
<!-- What problem does this solve? -->

This fixes phpstan errors:
```
 ------ ---------------------------------------------------------------------- 
  Line   src/Drush/Commands/PubSubCommands.php                                 
 ------ ---------------------------------------------------------------------- 
  51     Call to method writeln() on an unknown class Drush\Style\DrushStyle.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols   
  57     Call to method writeln() on an unknown class Drush\Style\DrushStyle.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols   
  60     Call to method writeln() on an unknown class Drush\Style\DrushStyle.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols   
 ------ ---------------------------------------------------------------------- 
```

More information: https://github.com/drush-ops/drush/issues/6110

[UHF-10844]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ