### PR TITLE
UHF-X: Change postcss processing so that css logical properties are preserved

### DIFF
--- a/public/themes/custom/hdbt_subtheme/postcss.config.js
+++ b/public/themes/custom/hdbt_subtheme/postcss.config.js
@@ -5,7 +5,15 @@ module.exports = {
   plugins: [
     // Plugins for PostCSS
     ['autoprefixer', { sourceMap: isDev }], // Parses CSS and adds vendor prefixes.
-    'postcss-preset-env', // Convert modern CSS into something most browsers can understand.
+    [
+      'postcss-preset-env', // Convert modern CSS into something most browsers can understand.
+      {
+        stage: 2, // Use stage 2 CSS features.
+        features: {
+          'logical-properties-and-values': false // Disable the conversion of css logical properties such as padding-inline.
+        },
+      },
+    ],
     'postcss-nested', // Unwrap nested rules like how Sass does it.
     'postcss-nesting', // Nest style rules inside each other, following the CSS Nesting specification.
     require('./postcss.plugins'), // Strip inline comments.


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change postcss processing so that the CSS logical properties such as padding-inline are preserved and not converted.

## How to install

* Check installation instructions from the hdbt PR.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the hdbt PR.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1149
