### PR TITLE
Make sure commit-msg Git hook is executable

### DIFF
--- a/tools/make/git.mk
+++ b/tools/make/git.mk
@@ -1,3 +1,3 @@
 PHONY += copy-commit-message-script
 copy-commit-message-script:
-	@$(foreach name,$(shell find . -type d -name ".git" -exec dirname {} \; 2> /dev/null ),cp tools/commit-msg $(name)/.git/hooks;)
+	@$(foreach name,$(shell find . -type d -name ".git" -exec dirname {} \; 2> /dev/null ),cp tools/commit-msg $(name)/.git/hooks && chmod +x $(name)/.git/hooks/commit-msg;)


### PR DESCRIPTION
## What was done

Git complains about non-executable hooks and it's never run:

> hint: The '.git/hooks/commit-msg' hook was ignored because it's not set as executable.
> hint: You can disable this warning with `git config advice.ignoredHook false`.

## How to install

* Copy the changed `tools/make/git.mk` file to your project

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure `.git/hooks/commit-msg` is not executable (in project root or in module/theme folders)
* [x] Run `make copy-commit-message-script` and make sure the script is now executable
