### PR TITLE
PLATTA-5751: Run deployment tasks in a separate job pod

### DIFF
--- a/docker/openshift/Dockerfile
+++ b/docker/openshift/Dockerfile
@@ -17,5 +17,9 @@ COPY docker/openshift/crons/ /crons
 COPY docker/openshift/cron-entrypoint.sh /usr/local/bin/cron-entrypoint
 RUN chmod +x /crons/* /usr/local/bin/cron-entrypoint
 
+# Copy drush deploy scripts
+COPY docker/openshift/drush-deploy-entrypoint.sh /usr/local/bin/drush-deploy-entrypoint
+RUN chmod +x /usr/local/bin/drush-deploy-entrypoint
+
 # Copy nginx overrides.
 COPY docker/openshift/custom.locations /etc/nginx/conf.d/custom.locations

--- a/docker/openshift/drush-deploy-entrypoint.sh
+++ b/docker/openshift/drush-deploy-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source /init.sh
+
+echo "Starting deploy: $(date)"
+
+# Populate deploy ID so 20-deploy.sh is skipped.
+# @todo Remove this once 20-deploy.sh is removed.
+set_deploy_id $OPENSHIFT_BUILD_NAME
+
+drush state:set system.maintenance_mode 1 --input-format=integer
+# Run pre-deploy tasks.
+# @see https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/blob/main/documentation/deploy-hooks.md
+drush helfi:pre-deploy || true
+# Run maintenance tasks (config import, database updates etc)
+drush deploy
+# Run post-deploy tasks.
+# @see https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/blob/main/documentation/deploy-hooks.md
+drush helfi:post-deploy || true
+# Disable maintenance mode
+drush state:set system.maintenance_mode 0 --input-format=integer


### PR DESCRIPTION
# [PLATTA-5751](https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-5751)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

The current deployment entrypoint has a 10 minute time limit before it's killed off. This PR adds an entrypoint that allows us to run deployment tasks in a separate job pod with no time limit constraints.

## Other PRs
- https://github.com/City-of-Helsinki/drupal-tools/pull/47
- https://dev.azure.com/City-of-Helsinki/helfi-rekry/_git/helfi-rekry-pipelines/pullrequest/10725