### PR TITLE
UHF-10647: Config override for etusivu elasticsearch (for suggestions indexing)

### DIFF
--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -365,6 +365,17 @@ if (getenv('ELASTICSEARCH_URL')) {
   }
 }
 
+// Elasticsearch suggestions server config. Etusivu elasticsearch instance is
+// shared between all core sites for indexing suggestions data.
+if (getenv('ELASTICSEARCH_ETUSIVU_URL')) {
+  $config['search_api.server.etusivu']['backend_config']['connector_config']['url'] = getenv('ELASTICSEARCH_ETUSIVU_URL');
+
+  if (getenv('ELASTICSEARCH_ETUSIVU_WRITER_USER') && getenv('ELASTICSEARCH_ETUSIVU_WRITER_PASSWORD')) {
+    $config['search_api.server.etusivu']['backend_config']['connector'] = 'helfi_connector';
+    $config['search_api.server.etusivu']['backend_config']['connector_config']['username'] = getenv('ELASTICSEARCH_ETUSIVU_WRITER_USER');
+    $config['search_api.server.etusivu']['backend_config']['connector_config']['password'] = getenv('ELASTICSEARCH_ETUSIVU_WRITER_PASSWORD');
+  }
+}
 
 // Supported values: https://github.com/Seldaek/monolog/blob/main/doc/01-usage.md#log-levels.
 $default_log_level = getenv('APP_ENV') === 'production' ? 'info' : 'debug';


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

## What was done

Adding a shared config override for etusivu elasticsearch, to allow writing to suggestions index from all core sites.

## How to test

We probably can't test this in local? So let's confirm this works in testing environments by checking the server connection status in /en/admin/config/search/search-api/server/etusivu , and making sure the suggestions index in etusivu is updated according to content updates

- Also test this on etusivu
- Select 1-2 additional sites and enable `helfi_recommendations` for testing 

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/917


[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ