### PR TITLE
UHF-9516: Add post-db-replace hooks

### DIFF
--- a/docker/openshift/Dockerfile
+++ b/docker/openshift/Dockerfile
@@ -7,10 +7,11 @@ RUN composer install --no-progress --profile --prefer-dist --no-interaction --no
 
 # Copy custom entrypoints.
 # @see https://github.com/City-of-Helsinki/drupal-docker-images/tree/main/openshift/drupal
-RUN mkdir -p /crons /entrypoints /deploy
+RUN mkdir -p /crons /entrypoints /hooks/deploy /hooks/post-db-replace
 COPY docker/openshift/entrypoints/ /entrypoints
 COPY docker/openshift/crons/ /crons
-COPY docker/openshift/deploy /deploy
-RUN chmod +x /entrypoints/* /deploy/* /crons/*
+COPY docker/openshift/deploy /hooks/deploy
+COPY docker/openshift/post-db-replace /hooks/post-db-replace
+RUN chmod +x /entrypoints/* /hooks/deploy/* /crons/* /hooks/post-db-replace/*
 
 COPY docker/openshift/init.sh /

--- a/docker/openshift/post-db-replace/10-prepare.sh
+++ b/docker/openshift/post-db-replace/10-prepare.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Run drush deploy after the database has been replaced.
+drush deploy

--- a/docker/openshift/post-db-replace/50-sanitize.sh
+++ b/docker/openshift/post-db-replace/50-sanitize.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ ! -z "$NO_OBFUSCATE_DATA" ]; then
+    echo "NO_OBFUSCATE_DATA is set. Skipping the step."
+    return
+fi
+
+# Obfuscate user data
+drush sql:sanitize

--- a/docker/openshift/post-db-replace/90-translations.sh
+++ b/docker/openshift/post-db-replace/90-translations.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+drush locale-check
+drush locale-update


### PR DESCRIPTION
# [UHF-9516](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9516)
<!-- What problem does this solve? -->

## How to install
* Change `DRUPAL_IMAGE` in `.env` to `ghcr.io/city-of-helsinki/drupal-web:8.3-dev`.
* Run: `docker compose pull && make fresh`
* Update helfi_drupal_tools: `composer require drupal/helfi_drupal_tools:dev-UHF-9516 drupal/helfi_tunnistamo:dev-UHF-9516`
* Update platform: `drush helfi:tools:update-platform --no-self-update --branch=UHF-9516`

How to test:
* [ ] Changed files look sensible: `git status`
* [ ] Run `make shell; sh ./docker/openshift/post-db-replace/50-sanitize.sh`
* [ ] Check `/admin/people`
* Setup tunnistamo: https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/?tab=readme-ov-file#local-development
  * [ ] Try to log-in with your own user.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-docker-images/pull/45
* https://github.com/City-of-Helsinki/drupal-tools/pull/53
* https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/pull/50


[UHF-9516]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ