### PR TITLE
UHF-9516: Fix typo in Dockerfile

### DIFF
--- a/docker/openshift/Dockerfile
+++ b/docker/openshift/Dockerfile
@@ -7,11 +7,11 @@ RUN composer install --no-progress --profile --prefer-dist --no-interaction --no
 
 # Copy custom entrypoints.
 # @see https://github.com/City-of-Helsinki/drupal-docker-images/tree/main/openshift/drupal
-RUN mkdir -p /crons /entrypoints /hooks/deploy /hooks/post-db-replace
+RUN mkdir -p /crons /entrypoints /hooks/deploy /hooks/db-replace
 COPY docker/openshift/entrypoints/ /entrypoints
 COPY docker/openshift/crons/ /crons
 COPY docker/openshift/deploy /hooks/deploy
-COPY docker/openshift/post-db-replace /hooks/post-db-replace
-RUN chmod +x /entrypoints/* /hooks/deploy/* /crons/* /hooks/post-db-replace/*
+COPY docker/openshift/post-db-replace /hooks/db-replace
+RUN chmod +x /entrypoints/* /hooks/deploy/* /crons/* /hooks/db-replace/*
 
 COPY docker/openshift/init.sh /


### PR DESCRIPTION
# [UHF-9516](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9516)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* See https://github.com/City-of-Helsinki/drupal-docker-images/blob/main/openshift/drupal/files/usr/local/bin/post-db-replace#L20

[UHF-9516]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ