### PR TITLE
UHF-11755: Proxy /ping to elasticsearch health endpoint

### DIFF
--- a/docker/elastic-proxy/elastic.conf
+++ b/docker/elastic-proxy/elastic.conf
@@ -3,24 +3,38 @@ server {
     server_name _;
     client_max_body_size 50m;
 
-    location /ping {
-      add_header Content-Type application/json;
-      return 200 '{"status":"success","result":"Proxy alive"}';
+    location /health {
+      access_log off;
+
+      proxy_pass ${ELASTICSEARCH_URL}/_cluster/health;
+      proxy_ssl_verify off;
+      proxy_redirect off;
+      proxy_set_header Authorization $elastic_authorization;
+      proxy_pass_header Authorization;
+
+      proxy_connect_timeout 5s;
+      proxy_send_timeout 5s;
+      proxy_read_timeout 5s;
     }
 
     location ~ ^/([a-z][a-z_,-]*)/(_search|_msearch)$ {
-        limit_except GET POST {
-           deny all;
+        limit_except GET POST OPTIONS {
+          deny all;
         }
+
+        if ($request_method = 'OPTIONS') {
+          return 204;
+        }
+
         proxy_pass ${ELASTICSEARCH_URL};
+        proxy_ssl_verify off;
         proxy_redirect off;
         proxy_set_header Authorization $elastic_authorization;
         proxy_pass_header Authorization;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
         proxy_pass_header Access-Control-Allow-Origin;
         proxy_pass_header Access-Control-Allow-Methods;
         proxy_hide_header Access-Control-Allow-Headers;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
     }
 }


### PR DESCRIPTION
# [UHF-11755](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11755)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

In elasticsearch proxy, forward /ping to elasticsearch health endpoint. The goal of this change is to make kubernetes kill the proxy if there are connection problems.


## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards


[UHF-11755]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ