### PR TITLE
Don't print "\n".

### DIFF
--- a/docker/openshift/crons/cron.sh
+++ b/docker/openshift/crons/cron.sh
@@ -2,7 +2,7 @@
 
 while true
 do
-  echo "Running cron: $(date +'%Y-%m-%dT%H:%M:%S%:z')\n"
+  echo "Running cron: $(date +'%Y-%m-%dT%H:%M:%S%:z')"
   drush cron
   # Sleep for 10 minutes.
   sleep 600


### PR DESCRIPTION
- Echo adds line eding on its own.
- This shows as "Running cron: 2026-02-27T10:46:59\n" in the logs. :)