### PR TITLE
UHF-13024: Adding a config override for CSP reporting endpoint uri

### DIFF
--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -378,6 +378,11 @@ if ($env !== 'production' && $e2e_test_user = getenv('E2E_TEST_USER')) {
   ]);
 }
 
+// Content Security Policy reporting URI.
+if ($csp_reporting_uri = getenv('CSP_REPORTING_URI')) {
+  $config['csp.settings']['enforce']['reporting']['options']['uri'] = $csp_reporting_uri;
+}
+
 if ($env !== 'production') {
   $stage_file_proxy_origin = getenv('STAGE_FILE_PROXY_ORIGIN');
   $stage_file_proxy_dir = getenv('STAGE_FILE_PROXY_ORIGIN_DIR');


### PR DESCRIPTION
# [UHF-13024](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13024)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Set CSP reporting endpoint uri from `CSP_REPORTING_URI`.
* Environment variable values added in https://dev.azure.com/City-of-Helsinki/helfi-etusivu/_git/helfi-variables/pullrequest/15975?_a=files

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1293


[UHF-13024]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ